### PR TITLE
[Feature #9] 홈화면 사용자 정보 조회

### DIFF
--- a/src/main/java/popcong/app/adapter/in/user/HomeController.java
+++ b/src/main/java/popcong/app/adapter/in/user/HomeController.java
@@ -1,0 +1,47 @@
+package popcong.app.adapter.in.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import popcong.app.application.user.dto.response.HomeUserResponseDto;
+import popcong.app.application.user.port.in.GetHomeInfoUseCase;
+import popcong.app.domain.user.model.User;
+import popcong.app.global.dto.ResponseDto;
+import popcong.app.global.exception.custom.BusinessException;
+import popcong.app.global.exception.error.AuthErrorCode;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/popup/home")
+public class HomeController {
+
+    private final GetHomeInfoUseCase getHomeInfoUseCase;
+
+    @GetMapping("/me")
+    public ResponseDto<HomeUserResponseDto> getHomeInfo(
+            @AuthenticationPrincipal User user,
+            @RequestParam(defaultValue = "5") int limit,
+            @RequestParam(defaultValue = "0") int offset
+    ) {
+        if (user == null) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        HomeUserResponseDto result =
+                getHomeInfoUseCase.getMyHomeInfo(user.userId(), limit, offset);
+
+        log.info("홈 정보 조회 성공 : userId={}", user.userId());
+
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
+                "홈 정보 조회 성공",
+                result
+        );
+    }
+}

--- a/src/main/java/popcong/app/adapter/in/user/HomeController.java
+++ b/src/main/java/popcong/app/adapter/in/user/HomeController.java
@@ -25,16 +25,14 @@ public class HomeController {
 
     @GetMapping("/me")
     public ResponseDto<HomeUserResponseDto> getHomeInfo(
-            @AuthenticationPrincipal User user,
-            @RequestParam(defaultValue = "5") int limit,
-            @RequestParam(defaultValue = "0") int offset
+            @AuthenticationPrincipal User user
     ) {
         if (user == null) {
             throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
         }
 
         HomeUserResponseDto result =
-                getHomeInfoUseCase.getMyHomeInfo(user.userId(), limit, offset);
+                getHomeInfoUseCase.getMyHomeInfo(user.userId());
 
         log.info("홈 정보 조회 성공 : userId={}", user.userId());
 

--- a/src/main/java/popcong/app/adapter/out/persistence/space/LoadMyPopupsPersistenceAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/LoadMyPopupsPersistenceAdapter.java
@@ -1,0 +1,37 @@
+package popcong.app.adapter.out.persistence.space;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import popcong.app.adapter.out.persistence.space.entity.PopupJpaEntity;
+import popcong.app.adapter.out.persistence.space.mapper.PopupEntityMapper;
+import popcong.app.adapter.out.persistence.space.repository.PopupJpaRepository;
+import popcong.app.application.space.dto.response.MyPopupItemResponseDto;
+import popcong.app.application.user.port.out.LoadMyPopupsPort;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class LoadMyPopupsPersistenceAdapter implements LoadMyPopupsPort {
+
+    private final PopupJpaRepository popupJpaRepository;
+
+    @Override
+    public List<MyPopupItemResponseDto> findMyPopups(Long userId, int limit, int offset) {
+        int safeLimit  = (limit <= 0) ? 5 : limit;
+        int safeOffset = Math.max(offset, 0);
+        int page = safeOffset / safeLimit;
+
+        Pageable pageable = PageRequest.of(page, safeLimit);   // 정렬은 메서드명에 포함
+
+        List<PopupJpaEntity> rows =
+                popupJpaRepository.findByReservationUserUserIdOrderByStartDateDesc(userId, pageable);
+
+        return rows.stream()
+                .map(PopupEntityMapper::toMyPopupItemResponseDto)
+                .toList();
+    }
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/space/LoadMyPopupsPersistenceAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/LoadMyPopupsPersistenceAdapter.java
@@ -22,7 +22,7 @@ public class LoadMyPopupsPersistenceAdapter implements LoadMyPopupsPort {
     public List<MyPopupItemResponseDto> findMyPopups(Long userId) {
 
         List<PopupJpaEntity> rows =
-                popupJpaRepository.findByReservationUserUserIdOrderByStartDateDesc(userId);
+                popupJpaRepository.findByReservationUserUserIdOrderByStartDateAsc(userId);
 
         return rows.stream()
                 .map(PopupEntityMapper::toMyPopupItemResponseDto)

--- a/src/main/java/popcong/app/adapter/out/persistence/space/LoadMyPopupsPersistenceAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/LoadMyPopupsPersistenceAdapter.java
@@ -1,8 +1,7 @@
 package popcong.app.adapter.out.persistence.space;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+
 import org.springframework.stereotype.Repository;
 
 import popcong.app.adapter.out.persistence.space.entity.PopupJpaEntity;
@@ -20,15 +19,10 @@ public class LoadMyPopupsPersistenceAdapter implements LoadMyPopupsPort {
     private final PopupJpaRepository popupJpaRepository;
 
     @Override
-    public List<MyPopupItemResponseDto> findMyPopups(Long userId, int limit, int offset) {
-        int safeLimit  = (limit <= 0) ? 5 : limit;
-        int safeOffset = Math.max(offset, 0);
-        int page = safeOffset / safeLimit;
-
-        Pageable pageable = PageRequest.of(page, safeLimit);   // 정렬은 메서드명에 포함
+    public List<MyPopupItemResponseDto> findMyPopups(Long userId) {
 
         List<PopupJpaEntity> rows =
-                popupJpaRepository.findByReservationUserUserIdOrderByStartDateDesc(userId, pageable);
+                popupJpaRepository.findByReservationUserUserIdOrderByStartDateDesc(userId);
 
         return rows.stream()
                 .map(PopupEntityMapper::toMyPopupItemResponseDto)

--- a/src/main/java/popcong/app/adapter/out/persistence/space/mapper/PopupEntityMapper.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/mapper/PopupEntityMapper.java
@@ -1,0 +1,38 @@
+package popcong.app.adapter.out.persistence.space.mapper;
+
+import popcong.app.adapter.out.persistence.space.entity.PopupJpaEntity;
+import popcong.app.adapter.out.persistence.space.entity.ReservationJpaEntity;
+import popcong.app.adapter.out.persistence.space.entity.SpaceJpaEntity;
+import popcong.app.application.space.dto.response.MyPopupItemResponseDto;
+import popcong.app.application.space.dto.response.SpaceInfoResponseDto;
+
+public final class PopupEntityMapper {
+    private PopupEntityMapper() {} // 유틸클래스(인스턴스 생성 방지)
+
+    public static MyPopupItemResponseDto toMyPopupItemResponseDto(PopupJpaEntity popup) {
+        //팝업이 속한 예약 엔티티 가져오기
+        ReservationJpaEntity r = popup.getReservation();
+        //예약 O -> 예약이 속한 공간 엔티티 가져오기
+        SpaceJpaEntity s = (r != null) ? r.getSpace() : null;
+
+        //MyPopupItemResponseDto 생성
+        return new MyPopupItemResponseDto(
+                SpaceInfoResponseDto.of( //공간정보 부분 생성
+                        (s != null) ? s.getSpaceId() : null, //공간 ID
+                        (s != null) ? s.getSpaceName() : null,     // 공간 이름
+                        (s != null && s.getFloor() != null)
+                                ? String.valueOf(s.getFloor())
+                                : null,
+                        //층 O -> String 으로 변환
+                        (popup.getAddress() != null) //팝업 주소 O -> 사용, 팝업 주소 X -> 공간 주소 사용
+                                ? popup.getAddress()
+                                : (s != null ? s.getAddress() : null)
+                ),
+                popup.getPopupId(),
+                popup.getName(),
+                popup.getPopupStatus(),
+                popup.getStartDate().toLocalDate(),
+                popup.getEndDate().toLocalDate()
+        );
+    }
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/space/repository/PopupJpaRepository.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/repository/PopupJpaRepository.java
@@ -13,5 +13,5 @@ public interface PopupJpaRepository extends JpaRepository<PopupJpaEntity, Long> 
 
      // 사용자별 팝업 목록 조회 (최신 시작일 내림차순)
     @EntityGraph(attributePaths = {"reservation", "reservation.space"}) //fetch 지정하여 추가쿼리 막음
-    List<PopupJpaEntity> findByReservationUserUserIdOrderByStartDateDesc(Long userId, Pageable pageable);
+    List<PopupJpaEntity> findByReservationUserUserIdOrderByStartDateDesc(Long userId);
 }

--- a/src/main/java/popcong/app/adapter/out/persistence/space/repository/PopupJpaRepository.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/repository/PopupJpaRepository.java
@@ -1,0 +1,17 @@
+package popcong.app.adapter.out.persistence.space.repository;
+
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import popcong.app.adapter.out.persistence.space.entity.PopupJpaEntity;
+
+import java.util.List;
+
+public interface PopupJpaRepository extends JpaRepository<PopupJpaEntity, Long> {
+
+
+     // 사용자별 팝업 목록 조회 (최신 시작일 내림차순)
+    @EntityGraph(attributePaths = {"reservation", "reservation.space"}) //fetch 지정하여 추가쿼리 막음
+    List<PopupJpaEntity> findByReservationUserUserIdOrderByStartDateDesc(Long userId, Pageable pageable);
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/space/repository/PopupJpaRepository.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/repository/PopupJpaRepository.java
@@ -1,7 +1,5 @@
 package popcong.app.adapter.out.persistence.space.repository;
 
-
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import popcong.app.adapter.out.persistence.space.entity.PopupJpaEntity;
@@ -10,8 +8,7 @@ import java.util.List;
 
 public interface PopupJpaRepository extends JpaRepository<PopupJpaEntity, Long> {
 
-
-     // 사용자별 팝업 목록 조회 (최신 시작일 내림차순)
-    @EntityGraph(attributePaths = {"reservation", "reservation.space"}) //fetch 지정하여 추가쿼리 막음
-    List<PopupJpaEntity> findByReservationUserUserIdOrderByStartDateDesc(Long userId);
+    // 사용자별 팝업 목록 조회 (시작일 오름차순)
+    @EntityGraph(attributePaths = {"reservation", "reservation.space"}) // N+1 방지
+    List<PopupJpaEntity> findByReservationUserUserIdOrderByStartDateAsc(Long userId);
 }

--- a/src/main/java/popcong/app/adapter/out/persistence/user/entity/UserJpaEntity.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/user/entity/UserJpaEntity.java
@@ -21,7 +21,7 @@ public class UserJpaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "usertId", nullable = false)
+    @Column(name = "userId", nullable = false)
     private Long userId;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/popcong/app/application/space/dto/response/MyPopupItemResponseDto.java
+++ b/src/main/java/popcong/app/application/space/dto/response/MyPopupItemResponseDto.java
@@ -1,0 +1,30 @@
+package popcong.app.application.space.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import popcong.app.domain.space.model.PopupStatus;
+
+
+import java.time.LocalDate;
+
+//외부 응답 전용 Dto
+@JsonInclude(JsonInclude.Include.NON_NULL) // 값이 Null인 필드를 응답에서 제외
+public record MyPopupItemResponseDto(
+        SpaceInfoResponseDto spaceInfo,
+        Long popupId,
+        String name,          // 팝업명
+        PopupStatus popupStatus,
+        LocalDate startDate,
+        LocalDate endDate
+
+){
+    public static MyPopupItemResponseDto of(
+            Long spaceId, String spaceName, String floor, String address,
+            Long popupId, String name, PopupStatus status,
+            LocalDate startDate, LocalDate endDate
+    ) {
+        return new MyPopupItemResponseDto(
+                SpaceInfoResponseDto.of(spaceId, spaceName, floor, address),
+                popupId, name, status, startDate, endDate
+        );
+    }
+}

--- a/src/main/java/popcong/app/application/space/dto/response/SpaceInfoResponseDto.java
+++ b/src/main/java/popcong/app/application/space/dto/response/SpaceInfoResponseDto.java
@@ -1,0 +1,13 @@
+package popcong.app.application.space.dto.response;
+
+public record SpaceInfoResponseDto(
+        Long spaceId,
+        String spaceName,
+        String floor,
+        String address
+) {
+    public static SpaceInfoResponseDto of(
+            Long spaceId, String spaceName,String floor ,String address) {
+        return new SpaceInfoResponseDto(spaceId, spaceName,floor, address);
+    }
+}

--- a/src/main/java/popcong/app/application/user/dto/response/HomeUserResponseDto.java
+++ b/src/main/java/popcong/app/application/user/dto/response/HomeUserResponseDto.java
@@ -1,0 +1,16 @@
+package popcong.app.application.user.dto.response;
+
+import popcong.app.application.space.dto.response.MyPopupItemResponseDto;
+import java.util.List;
+
+public record HomeUserResponseDto(
+        UserInfoResponseDto userInfo,
+        List<MyPopupItemResponseDto> myPopups
+) {
+    public static HomeUserResponseDto from(UserResponseDto user, List<MyPopupItemResponseDto> popups) {
+        return new HomeUserResponseDto(
+                UserInfoResponseDto.from(user),
+                popups
+        );
+    }
+}

--- a/src/main/java/popcong/app/application/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/popcong/app/application/user/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,9 @@
+package popcong.app.application.user.dto.response;
+
+public record UserInfoResponseDto(
+        String name
+) {
+    public static UserInfoResponseDto from(UserResponseDto user) {
+        return new UserInfoResponseDto(user.name());
+    }
+}

--- a/src/main/java/popcong/app/application/user/port/in/GetHomeInfoUseCase.java
+++ b/src/main/java/popcong/app/application/user/port/in/GetHomeInfoUseCase.java
@@ -1,0 +1,7 @@
+package popcong.app.application.user.port.in;
+
+import popcong.app.application.user.dto.response.HomeUserResponseDto;
+
+public interface GetHomeInfoUseCase {
+    HomeUserResponseDto getMyHomeInfo(Long userId, int limit, int offset);
+}

--- a/src/main/java/popcong/app/application/user/port/in/GetHomeInfoUseCase.java
+++ b/src/main/java/popcong/app/application/user/port/in/GetHomeInfoUseCase.java
@@ -3,5 +3,5 @@ package popcong.app.application.user.port.in;
 import popcong.app.application.user.dto.response.HomeUserResponseDto;
 
 public interface GetHomeInfoUseCase {
-    HomeUserResponseDto getMyHomeInfo(Long userId, int limit, int offset);
+    HomeUserResponseDto getMyHomeInfo(Long userId);
 }

--- a/src/main/java/popcong/app/application/user/port/out/LoadMyPopupsPort.java
+++ b/src/main/java/popcong/app/application/user/port/out/LoadMyPopupsPort.java
@@ -5,6 +5,5 @@ import popcong.app.application.space.dto.response.MyPopupItemResponseDto;
 import java.util.List;
 
 public interface LoadMyPopupsPort {
-    List<MyPopupItemResponseDto> findMyPopups(Long userId, int limit, int offset);
-    //limit,offset -> 페이징
+    List<MyPopupItemResponseDto> findMyPopups(Long userId);
 }

--- a/src/main/java/popcong/app/application/user/port/out/LoadMyPopupsPort.java
+++ b/src/main/java/popcong/app/application/user/port/out/LoadMyPopupsPort.java
@@ -1,0 +1,10 @@
+package popcong.app.application.user.port.out;
+
+import popcong.app.application.space.dto.response.MyPopupItemResponseDto;
+
+import java.util.List;
+
+public interface LoadMyPopupsPort {
+    List<MyPopupItemResponseDto> findMyPopups(Long userId, int limit, int offset);
+    //limit,offset -> 페이징
+}

--- a/src/main/java/popcong/app/application/user/service/HomeInfoService.java
+++ b/src/main/java/popcong/app/application/user/service/HomeInfoService.java
@@ -1,0 +1,42 @@
+package popcong.app.application.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import org.springframework.transaction.annotation.Transactional;
+import popcong.app.application.user.dto.response.HomeUserResponseDto;
+import popcong.app.application.user.dto.response.UserResponseDto;
+import popcong.app.application.user.port.in.GetHomeInfoUseCase;
+import popcong.app.application.user.port.out.LoadMyPopupsPort;
+import popcong.app.application.user.port.out.LoadUserPort;
+import popcong.app.application.space.dto.response.MyPopupItemResponseDto;
+import popcong.app.domain.user.model.User;
+import popcong.app.global.exception.custom.BusinessException;
+import popcong.app.global.exception.error.AuthErrorCode;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HomeInfoService implements GetHomeInfoUseCase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadMyPopupsPort loadMyPopupsPort;
+
+    @Override
+    @Transactional(readOnly = true)
+    public HomeUserResponseDto getMyHomeInfo(Long userId, int limit, int offset) {
+        // 사용자 조회 (없으면 예외)
+        User user = loadUserPort.loadUserById(userId)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.UNAUTHORIZED));
+
+        // 내 팝업 조회
+        List<MyPopupItemResponseDto> myPopups =
+                loadMyPopupsPort.findMyPopups(userId, limit, offset);
+
+        // 응답 DTO 조합
+        return HomeUserResponseDto.from(UserResponseDto.from(user), myPopups);
+    }
+
+}
+

--- a/src/main/java/popcong/app/application/user/service/HomeInfoService.java
+++ b/src/main/java/popcong/app/application/user/service/HomeInfoService.java
@@ -25,14 +25,14 @@ public class HomeInfoService implements GetHomeInfoUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public HomeUserResponseDto getMyHomeInfo(Long userId, int limit, int offset) {
+    public HomeUserResponseDto getMyHomeInfo(Long userId) {
         // 사용자 조회 (없으면 예외)
         User user = loadUserPort.loadUserById(userId)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.UNAUTHORIZED));
 
         // 내 팝업 조회
         List<MyPopupItemResponseDto> myPopups =
-                loadMyPopupsPort.findMyPopups(userId, limit, offset);
+                loadMyPopupsPort.findMyPopups(userId);
 
         // 응답 DTO 조합
         return HomeUserResponseDto.from(UserResponseDto.from(user), myPopups);


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#9 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요.

### 홈화면에서 사용자 정보 조회 로직 추가

### Mypopups 조회 로직 추가
- PopupJpaRepository에 사용자별 팝업 목록 조회 메서드 추가
- JPA @EntityGraph 적용으로 N+1 방지
- LoadMyPopupsPersistenceAdapter 구현체 작성
- 페이지네이션 지원

### Mypopups 응답 DTO, Mapper 추가
- PopupEntityMapper 작성, Entity → DTO 변환 로직 구현
- space , popup 정보를 포함한 변환 지원


### 홈 정보 조회 API에 MyPopups 포함
- HomeInfoService에서 LoadMyPopupsPort 호출 추가
- HomeController에서 MyPopups 응답 포함하도록 수정



## 📸 Screenshot

### 홈 정보 조회 성공 - myPopup데이터가 없을때
<img width="2032" height="1308" alt="image" src="https://github.com/user-attachments/assets/7bf99917-2b5a-450b-8f8b-8cb0fbe41b78" />

### 홈 정보 조회 성공 -myPopup 데이터 있음
<img width="2028" height="1468" alt="image" src="https://github.com/user-attachments/assets/f92904f6-e1e2-4da9-a86f-d69f762619fa" />

### 시작 날짜가 가까운 순으로 뜸 -> 수정함
<img width="1075" height="768" alt="image" src="https://github.com/user-attachments/assets/d4aec830-5158-4963-a1c5-07b7be62a338" />


### 401 인증되지 않은 사용자
<img width="2006" height="934" alt="image" src="https://github.com/user-attachments/assets/9868c41a-98f9-46d5-bf21-4c67e4c8ed2b" />




## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.