### PR TITLE
[feature] S3 이미지 업로드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,12 @@ dependencies {
 
 	// Validation
 	implementation 'jakarta.validation:jakarta.validation-api:3.1.0'
+
+	//AWS
+	implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.700')
+	implementation 'com.amazonaws:aws-java-sdk-s3'   // S3
+	implementation 'com.amazonaws:aws-java-sdk-sts'
+
 }
 
 // Q타입 엔티티가 생성될 경로

--- a/src/main/java/popcong/app/adapter/in/image/ImageController.java
+++ b/src/main/java/popcong/app/adapter/in/image/ImageController.java
@@ -1,0 +1,42 @@
+package popcong.app.adapter.in.image;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import popcong.app.adapter.out.persistence.image.entity.ImageJpaEntity;
+import popcong.app.application.image.service.ImageService;
+import popcong.app.domain.image.model.ImageableType;
+import popcong.app.global.dto.ResponseDto;
+
+import java.util.List;
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/images")
+public class ImageController {
+    private final ImageService imageService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseDto<ImageJpaEntity> upload(
+            @RequestParam("imageableId") Long imageableId,
+            @RequestParam("imageableType") ImageableType imageableType,
+            @RequestParam("saveOrder") Integer saveOrder,
+            @RequestPart("file") MultipartFile file
+    ) {
+        ImageJpaEntity saved = imageService.upload(imageableType,imageableId,saveOrder, file);
+        return new ResponseDto<>(HttpStatus.CREATED.value(), "이미지 업로드 성공", saved);
+    }
+
+    @GetMapping
+    public ResponseDto<List<ImageJpaEntity>> list(
+            @RequestParam("imageableId") Long imageableId,
+            @RequestParam("imageableType") ImageableType imageableType
+    ) {
+        List<ImageJpaEntity> images = imageService.list(imageableId, imageableType);
+        return new ResponseDto<>(HttpStatus.OK.value(), "이미지 목록 조회 성공", images);
+    }
+
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/image/repository/ImageJpaRepository.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/image/repository/ImageJpaRepository.java
@@ -4,11 +4,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import popcong.app.adapter.out.persistence.image.entity.ImageJpaEntity;
 import popcong.app.domain.image.model.ImageableType;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ImageJpaRepository extends JpaRepository<ImageJpaEntity, Long> {
 
     Optional<ImageJpaEntity> findByImageableTypeAndImageableIdAndSaveOrder(
             ImageableType imageableType, Long imageableId, Integer saveOrder
+    );
+
+    List<ImageJpaEntity> findByImageableIdAndImageableTypeOrderBySaveOrderAsc(
+            Long imageableId, ImageableType imageableType
     );
 }

--- a/src/main/java/popcong/app/application/image/service/ImageService.java
+++ b/src/main/java/popcong/app/application/image/service/ImageService.java
@@ -1,0 +1,88 @@
+package popcong.app.application.image.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import popcong.app.adapter.out.persistence.image.entity.ImageJpaEntity;
+import popcong.app.adapter.out.persistence.image.repository.ImageJpaRepository;
+import popcong.app.domain.image.model.ImageableType;
+import popcong.app.global.exception.custom.BusinessException;
+import popcong.app.global.exception.error.ImageS3ErrorCode;
+
+import java.util.List;
+import java.util.Locale;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Service s3Service;  // S3 업로드 담당
+    private final ImageJpaRepository imageRepository; // Image 테이블 JPA
+
+    /** 업로드 + DB 저장 */
+    public ImageJpaEntity upload(
+                                 ImageableType imageableType,
+                                 Long imageableId,
+                                 int saveOrder,
+                                 MultipartFile file) {
+
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ImageS3ErrorCode.FILE_NOT_FOUND);
+        }
+
+        // 키 생성 (profile/123/0.jpg)
+        String key = buildKey(imageableType, imageableId, saveOrder, file);
+
+        // S3 업로드 후 URL 반환
+        String url = s3Service.uploadFile(key, file);
+
+        // DB에 저장 (있으면 업데이트, 없으면 새로 생성)
+        ImageJpaEntity entity = imageRepository
+                .findByImageableTypeAndImageableIdAndSaveOrder(imageableType, imageableId, Integer.valueOf(saveOrder))
+                .map(existing -> ImageJpaEntity.builder()
+                        .imageId(existing.getImageId())
+                        .imageUrl(url)
+                        .saveOrder(saveOrder)
+                        .imageableId(imageableId)
+                        .imageableType(imageableType)
+                        .build()
+                )
+                .orElseGet(() -> ImageJpaEntity.builder()
+                        .imageUrl(url)
+                        .saveOrder(saveOrder)
+                        .imageableId(imageableId)
+                        .imageableType(imageableType)
+                        .build()
+                );
+
+        return imageRepository.save(entity);
+    }
+
+    /** 목록 조회 */
+    public List<ImageJpaEntity> list(Long imageableId, ImageableType imageableType) {
+        return imageRepository.findByImageableIdAndImageableTypeOrderBySaveOrderAsc(
+                imageableId, imageableType
+        );
+    }
+
+    // 내부 유틸
+
+    private String buildKey(ImageableType type, Long imageableId, int saveOrder, MultipartFile file) {
+        String prefix = type.name().toLowerCase(Locale.ROOT);
+        String ext = guessExt(file);
+        return prefix + "/" + imageableId + "/" + saveOrder + "." + ext;
+    }
+
+    private String guessExt(MultipartFile file) {
+        String name = file.getOriginalFilename();
+        if (name != null) {
+            int dot = name.lastIndexOf('.');
+            if (dot > -1 && dot < name.length() - 1) {
+                return name.substring(dot + 1).toLowerCase(Locale.ROOT);
+            }
+        }
+        return "jpg";
+    }
+}

--- a/src/main/java/popcong/app/application/image/service/S3Service.java
+++ b/src/main/java/popcong/app/application/image/service/S3Service.java
@@ -1,0 +1,73 @@
+
+package popcong.app.application.image.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import popcong.app.global.exception.custom.BusinessException;
+import popcong.app.global.exception.error.ImageS3ErrorCode;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+
+    // 성공 시 S3 URL 반환
+    public String uploadFile(String key, MultipartFile file) {
+
+        // 입력 검증
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ImageS3ErrorCode.FILE_NOT_FOUND);
+        }
+        try {
+            //메타 데이터 설정
+            ObjectMetadata md = new ObjectMetadata();
+            md.setContentLength(file.getSize()); // S3가 스트림을 읽을 크기
+            if (file.getContentType() != null) { //브라우저/클라이언트가 파일을 다룰때 도움
+                md.setContentType(file.getContentType()); //다운로드 표시에 유용한 헤더
+            }
+
+            // 로그확인
+            log.info("[S3 PUT] bucket={}, key={}, size={}, contentType={}",
+                    bucket, key, file.getSize(), file.getContentType());
+
+            //key "버킷 내부 경로/파일명", 호출자가 key를 만들어 넘김 -> 서비스는 업로드만 담당
+            amazonS3.putObject(bucket, key, file.getInputStream(), md);
+            return amazonS3.getUrl(bucket, key).toString(); //getUrl -> 저장 위치 식별자로 씀
+
+        } catch (IOException e) {
+            log.warn("S3 upload IOException (key={}): {}", key, e.getMessage(), e);
+            throw new BusinessException(ImageS3ErrorCode.FILE_UPLOAD_ERROR);
+
+        } catch (AmazonServiceException e) {
+            //S3가 HTTP 오류로 응답한 경우
+            int status = e.getStatusCode();
+            log.warn("S3 upload failed: status={}, awsCode={}, msg={}",
+                    status, e.getErrorCode(), e.getMessage(), e);
+
+            if (status == 403) throw new BusinessException(ImageS3ErrorCode.STORAGE_ACCESS_DENIED); //권한 없음
+            if (status == 404) throw new BusinessException(ImageS3ErrorCode.FILE_NOT_FOUND); // 파일 없음
+            if (status == 413) throw new BusinessException(ImageS3ErrorCode.FILE_TOO_LARGE); //용량
+
+            throw new BusinessException(ImageS3ErrorCode.FILE_UPLOAD_ERROR);
+
+        } catch (RuntimeException e) { //네트워크 문제등을 포함한 대부분 런타임 문제
+        log.warn("S3 client/runtime error (key={}): {}", key, e.getMessage(), e);
+        throw new BusinessException(ImageS3ErrorCode.FILE_UPLOAD_ERROR);
+
+        }
+    }
+}

--- a/src/main/java/popcong/app/global/exception/error/ImageS3ErrorCode.java
+++ b/src/main/java/popcong/app/global/exception/error/ImageS3ErrorCode.java
@@ -1,0 +1,29 @@
+package popcong.app.global.exception.error;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import popcong.app.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ImageS3ErrorCode implements ErrorCode {
+
+    //4xx
+    FILE_NOT_FOUND        (HttpStatus.NOT_FOUND.value(),           "IMG4040", "요청한 파일을 찾을 수 없습니다."),
+    FILE_TOO_LARGE        (HttpStatus.PAYLOAD_TOO_LARGE.value(),   "IMG4130", "파일 크기 제한을 초과했습니다."),
+    STORAGE_ACCESS_DENIED (HttpStatus.FORBIDDEN.value(),           "IMG4030", "스토리지 접근 권한이 없습니다."),
+    INVALID_CONTENT_TYPE  (HttpStatus.BAD_REQUEST.value(),         "IMG4001", "지원하지 않는 콘텐츠 타입입니다."),
+
+    // 5xx
+    FILE_UPLOAD_ERROR     (HttpStatus.INTERNAL_SERVER_ERROR.value(),"IMG5001", "파일 업로드 중 오류가 발생했습니다."),
+    FILE_DOWNLOAD_ERROR   (HttpStatus.INTERNAL_SERVER_ERROR.value(),"IMG5002", "파일 다운로드 중 오류가 발생했습니다."),
+    FILE_DELETE_ERROR     (HttpStatus.INTERNAL_SERVER_ERROR.value(),"IMG5003", "파일 삭제 중 오류가 발생했습니다.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/popcong/app/infra/config/s3/S3Config.java
+++ b/src/main/java/popcong/app/infra/config/s3/S3Config.java
@@ -1,0 +1,70 @@
+package popcong.app.infra.config.s3;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.annotation.Order;
+
+@Slf4j
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.region:us-east-2}")
+    private String region;
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider(
+            @Value("${cloud.aws.profile:}") String profile) {
+        log.info("[S3] Using profile='{}', region='{}'", profile, region);
+        return (profile != null && !profile.isBlank())
+                ? new ProfileCredentialsProvider(profile)
+                : DefaultAWSCredentialsProviderChain.getInstance();
+    }
+
+    @Bean
+    @Primary
+    public AmazonS3 amazonS3(AWSCredentialsProvider creds) {
+        log.info("[S3] Creds provider = {}", creds.getClass().getSimpleName());
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(Regions.fromName(region))
+                .withCredentials(creds)
+                .withForceGlobalBucketAccessEnabled(true)
+                .build();
+    }
+
+    @Bean
+    public AWSSecurityTokenService sts(AWSCredentialsProvider creds) {
+        return AWSSecurityTokenServiceClientBuilder.standard()
+                .withRegion(Regions.fromName(region))
+                .withCredentials(creds)
+                .build();
+    }
+
+    // 앱 기동 후 한 번만 실행되며, 현재 STS 호출 주체를 로깅
+    @Bean
+    @Order(0)
+    public ApplicationRunner logCaller(AWSSecurityTokenService sts) {
+        return args -> {
+            try {
+                var me = sts.getCallerIdentity(
+                        new com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest());
+                log.info("AWS caller identity: account={}, arn={}, userId={}",
+                        me.getAccount(), me.getArn(), me.getUserId());
+            } catch (Exception e) {
+                log.error("Failed to resolve AWS caller identity.", e);
+            }
+        };
+
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,10 @@ spring:
         format_sql: true
         show_sql: true
     open-in-view: false
+
+cloud:
+  aws:
+    profile: dev
+    region: us-east-2     # 버킷 리전
+    s3:
+      bucket: popcongbucket


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#17 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요.

### S3Config
- AWS S3 연결 설정 담당
- 내 로컬에서 쓰는 AWS Profile / 기본 인증 체인 사용
- 앱 시작 시 AWS 계정 정보를 log로 찍음 -> 맞는 계정인지 확인 가능

### S3Service
- 실제 업로드 처리
- 업로드 성공시 URL 반환 (DB저장할때 이 URL 사용)
- BusinessException 처리(파일X, 권한/용량 문제, 네트워크 오류 등)

### ImageService
- 이미지 업로드 -> DB저장 연결해주는 로직
- S3에 저장할 key 생성 -> S3Service 호출, 파일 업로드 -> URL 확보 -> DB에 URL 저장

### ImageJpaRepository
- findByImageableIdAndImageableTypeOrderBySaveOrderAsc 
→ 엔티티별 이미지 리스트 정렬해서 가져오기

### ImageController
- POST / api/vi/images
- Params : imageableId, imageableType, saveOrder, file ( S3 업로드 -> DB저장 -> 저장된 데이터 반환)
- GET / api / v1 / images
- > 해당 엔티티의 이미지 리스트 반환


## 📸 Screenshot
-> 성공
<img width="2104" height="1532" alt="image" src="https://github.com/user-attachments/assets/e8720f62-7f02-49a7-abb0-8c277b965432" />



## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

<img width="1556" height="472" alt="image" src="https://github.com/user-attachments/assets/59ed5e91-d8cf-4acc-9a18-2a5376d36afd" />

### 요청에서 어떤 파라미터 넘기나요?
- POST/api/v1/images
- 요청 파라미터
   - imageableId 
   - imageableType : PROFILE 등 ENUM 값
   - saveOrder
   - file : 실제 업로드 할 이미지 파일
 
### 처리과정
S3key 생성 -> 이미지를 AWS S3 버킷에 업로드 -> 업로드 된 파일의 S3 URL을 생성 후 DB에 저장

### 응답 예시
<img width="673" height="225" alt="image" src="https://github.com/user-attachments/assets/48b26da6-e812-4e14-be13-73f815df347d" />
