### PR TITLE
[Feature] 내 프로필 조회 + 프로필 편집 기능 구현

### DIFF
--- a/src/main/java/popcong/app/adapter/in/user/UserController.java
+++ b/src/main/java/popcong/app/adapter/in/user/UserController.java
@@ -139,4 +139,19 @@ public class UserController {
                 result
         );
     }
+    @GetMapping("/mypage/me")
+    public ResponseDto<UserResponseDto> getMyProfile(@AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+        log.info("내 프로필 조회 성공 : userId = {}, email = {}", user.userId(), user.email());
+
+        UserResponseDto result = UserResponseDto.from(user);
+
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
+                "나의 프로필 조회 성공",
+                result
+        );
+    }
 }

--- a/src/main/java/popcong/app/adapter/in/user/UserController.java
+++ b/src/main/java/popcong/app/adapter/in/user/UserController.java
@@ -8,7 +8,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import popcong.app.application.auth.port.in.GoogleDriveSubmitUseCase;
+import popcong.app.application.user.dto.response.MyProfileResponseDto;
 import popcong.app.application.user.dto.response.UserResponseDto;
+import popcong.app.application.user.port.in.GetMyProfileUseCase;
 import popcong.app.application.user.port.in.UserInfoUseCase;
 import popcong.app.domain.user.model.DocumentType;
 import popcong.app.domain.user.model.SignUpUserType;
@@ -30,6 +32,7 @@ public class UserController {
 
     private final GoogleDriveSubmitUseCase googleDriveSubmitUseCase;
     private final UserInfoUseCase userInfoUseCase;
+    private final GetMyProfileUseCase getMyProfileUseCase;
 
 
     /**
@@ -121,8 +124,7 @@ public class UserController {
                 null
         );
     }
-
-
+    //사용자 조회
     @GetMapping("/me")
     public ResponseDto<UserResponseDto> getUserInfo(@AuthenticationPrincipal User user) {
         if (user == null) {
@@ -139,19 +141,19 @@ public class UserController {
                 result
         );
     }
+    // 내 프로필 조회
     @GetMapping("/mypage/me")
-    public ResponseDto<UserResponseDto> getMyProfile(@AuthenticationPrincipal User user) {
-        if (user == null) {
-            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
-        }
-        log.info("내 프로필 조회 성공 : userId = {}, email = {}", user.userId(), user.email());
+    public ResponseDto<MyProfileResponseDto> getMyProfile(@AuthenticationPrincipal User user) {
+        if (user == null) throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
 
-        UserResponseDto result = UserResponseDto.from(user);
+        // ✅ 타입명이 아니라, 주입받은 인스턴스로 호출
+        MyProfileResponseDto dto = getMyProfileUseCase.get(user.userId());
 
         return new ResponseDto<>(
                 HttpStatus.OK.value(),
-                "나의 프로필 조회 성공",
-                result
+                "내 프로필 조회 성공",
+                dto
         );
     }
 }
+

--- a/src/main/java/popcong/app/adapter/in/user/UserController.java
+++ b/src/main/java/popcong/app/adapter/in/user/UserController.java
@@ -8,9 +8,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import popcong.app.application.auth.port.in.GoogleDriveSubmitUseCase;
+import popcong.app.application.image.port.out.ProfileImageUploadPort;
 import popcong.app.application.user.dto.response.MyProfileResponseDto;
 import popcong.app.application.user.dto.response.UserResponseDto;
 import popcong.app.application.user.port.in.GetMyProfileUseCase;
+import popcong.app.application.user.port.in.UpdateMyProfileUseCase;
 import popcong.app.application.user.port.in.UserInfoUseCase;
 import popcong.app.domain.user.model.DocumentType;
 import popcong.app.domain.user.model.SignUpUserType;
@@ -33,6 +35,8 @@ public class UserController {
     private final GoogleDriveSubmitUseCase googleDriveSubmitUseCase;
     private final UserInfoUseCase userInfoUseCase;
     private final GetMyProfileUseCase getMyProfileUseCase;
+    private final UpdateMyProfileUseCase updateMyProfileUseCase;
+    private final ProfileImageUploadPort profileImageUploadPort;
 
 
     /**
@@ -153,6 +157,29 @@ public class UserController {
                 HttpStatus.OK.value(),
                 "내 프로필 조회 성공",
                 dto
+        );
+    }
+
+    //프로필 편집
+    @PatchMapping(value = "/my/update-profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseDto<Void> updateMyProfile(
+            @AuthenticationPrincipal User user,
+            @RequestPart(required = false) String name,
+            @RequestPart(required = false) String introduction,
+            @RequestPart(required = false) MultipartFile profileImage
+    ){
+        if (user == null) throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+
+        String profileImageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            profileImageUrl = profileImageUploadPort.uploadProfileImage(user.userId(), profileImage);
+        }
+        updateMyProfileUseCase.update(user.userId(), name, introduction, profileImageUrl);
+
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
+                "프로필 편집 성공",
+                null
         );
     }
 }

--- a/src/main/java/popcong/app/adapter/in/user/UserController.java
+++ b/src/main/java/popcong/app/adapter/in/user/UserController.java
@@ -150,7 +150,7 @@ public class UserController {
     public ResponseDto<MyProfileResponseDto> getMyProfile(@AuthenticationPrincipal User user) {
         if (user == null) throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
 
-        // ✅ 타입명이 아니라, 주입받은 인스턴스로 호출
+
         MyProfileResponseDto dto = getMyProfileUseCase.get(user.userId());
 
         return new ResponseDto<>(

--- a/src/main/java/popcong/app/adapter/out/image/S3ProfileImageUploadAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/image/S3ProfileImageUploadAdapter.java
@@ -1,0 +1,57 @@
+package popcong.app.adapter.out.image;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import popcong.app.application.image.port.out.ProfileImageUploadPort;
+import popcong.app.global.exception.custom.BusinessException;
+import popcong.app.global.exception.error.ImageS3ErrorCode;
+
+import java.io.IOException;
+
+
+@Slf4j
+@Component
+public class S3ProfileImageUploadAdapter implements ProfileImageUploadPort {
+
+    private final AmazonS3 s3;
+    private final String bucket = "popcongbucket";
+    private final Regions region = Regions.US_EAST_2; //오하이오
+
+    public S3ProfileImageUploadAdapter() {
+        this.s3 = AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(DefaultAWSCredentialsProviderChain.getInstance())
+                .build();
+    }
+
+    @Override
+    public String uploadProfileImage(Long userId, MultipartFile file) {
+        try {
+            String key = buildKey(userId, file.getOriginalFilename());
+
+            ObjectMetadata meta = new ObjectMetadata();
+            meta.setContentLength(file.getSize());
+            meta.setContentType(file.getContentType());
+
+            PutObjectRequest req = new PutObjectRequest(bucket, key, file.getInputStream(), meta);
+            s3.putObject(req);
+
+            return "https://%s.s3.%s.amazonaws.com/%s"
+                    .formatted(bucket, region.getName(), key);
+
+        } catch (IOException e) {
+            log.error("S3 업로드 실패", e);
+            throw new BusinessException(ImageS3ErrorCode.FILE_UPLOAD_ERROR);
+        }
+    }
+    private String buildKey(Long userId, String original) {
+        String safe = (original == null ? "unknown" : original).replaceAll("\\s+", "_");
+        return "profiles/%d/%d_%s".formatted(userId, System.currentTimeMillis(), safe);
+    }
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/user/entity/UserJpaEntity.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/user/entity/UserJpaEntity.java
@@ -59,4 +59,17 @@ public class UserJpaEntity {
 
     @Column(name = "deletedAt")
     private LocalDateTime deletedAt;
+
+    //변경 메서드
+    public void changeName(String name) {
+        this.name = name;
+    }
+
+    public void changeIntroduction(String introduction) {
+        this.introduction = introduction;
+    }
+
+    public void changeProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/popcong/app/adapter/out/user/UpdateUserAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/user/UpdateUserAdapter.java
@@ -1,0 +1,31 @@
+// popcong.app.adapter.out.user.UpdateUserAdapter
+package popcong.app.adapter.out.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import popcong.app.adapter.out.persistence.user.entity.UserJpaEntity;
+import popcong.app.adapter.out.persistence.user.repository.UserJpaRepository;
+import popcong.app.application.user.port.out.UpdateUserPort;
+import popcong.app.global.exception.custom.BusinessException;
+import popcong.app.global.exception.error.AuthErrorCode;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateUserAdapter implements UpdateUserPort {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    @Transactional
+    public void updateProfile(Long userId, String name, String introduction, String profileImageUrl) {
+        UserJpaEntity user = userJpaRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+
+        if (name != null) user.changeName(name);
+        if (introduction != null) user.changeIntroduction(introduction);
+        if (profileImageUrl != null) user.changeProfileImageUrl(profileImageUrl);
+
+
+    }
+}

--- a/src/main/java/popcong/app/application/image/port/out/ProfileImageUploadPort.java
+++ b/src/main/java/popcong/app/application/image/port/out/ProfileImageUploadPort.java
@@ -1,0 +1,7 @@
+package popcong.app.application.image.port.out;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ProfileImageUploadPort {
+    String uploadProfileImage(Long userId, MultipartFile file);
+}

--- a/src/main/java/popcong/app/application/user/dto/response/MyProfileResponseDto.java
+++ b/src/main/java/popcong/app/application/user/dto/response/MyProfileResponseDto.java
@@ -1,0 +1,21 @@
+package popcong.app.application.user.dto.response;
+
+import popcong.app.domain.user.model.User;
+
+public record MyProfileResponseDto(
+        Long userId,
+        String name,
+        String introduce,
+        String profileImageUrl,
+        String userRole
+) {
+    public static MyProfileResponseDto from(User user) {
+        return new MyProfileResponseDto(
+                user.userId(),
+                user.name(),
+                user.introduction(),
+                user.profileImageUrl(),
+                user.userRole().name()
+        );
+    }
+}

--- a/src/main/java/popcong/app/application/user/port/in/GetMyProfileUseCase.java
+++ b/src/main/java/popcong/app/application/user/port/in/GetMyProfileUseCase.java
@@ -1,0 +1,7 @@
+package popcong.app.application.user.port.in;
+
+import popcong.app.domain.user.model.User;
+
+public interface GetMyProfileUseCase {
+    User getMyProfile(Long userId);
+}

--- a/src/main/java/popcong/app/application/user/port/in/GetMyProfileUseCase.java
+++ b/src/main/java/popcong/app/application/user/port/in/GetMyProfileUseCase.java
@@ -1,7 +1,7 @@
 package popcong.app.application.user.port.in;
 
-import popcong.app.domain.user.model.User;
+import popcong.app.application.user.dto.response.MyProfileResponseDto;
 
 public interface GetMyProfileUseCase {
-    User getMyProfile(Long userId);
+    MyProfileResponseDto get(Long userId);
 }

--- a/src/main/java/popcong/app/application/user/port/in/UpdateMyProfileUseCase.java
+++ b/src/main/java/popcong/app/application/user/port/in/UpdateMyProfileUseCase.java
@@ -1,0 +1,10 @@
+package popcong.app.application.user.port.in;
+
+public interface UpdateMyProfileUseCase {
+    void update(Long userId,
+                String name,
+                String introduction,
+                String profileImageUrl
+    );
+
+}

--- a/src/main/java/popcong/app/application/user/port/out/UpdateUserPort.java
+++ b/src/main/java/popcong/app/application/user/port/out/UpdateUserPort.java
@@ -1,0 +1,5 @@
+package popcong.app.application.user.port.out;
+
+public interface UpdateUserPort {
+    void updateProfile(Long userId, String name, String introduction, String profileImageUrl);
+}

--- a/src/main/java/popcong/app/application/user/service/GetMyProfileService.java
+++ b/src/main/java/popcong/app/application/user/service/GetMyProfileService.java
@@ -2,6 +2,7 @@ package popcong.app.application.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import popcong.app.application.user.dto.response.MyProfileResponseDto;
 import popcong.app.application.user.port.in.GetMyProfileUseCase;
 import popcong.app.application.user.port.out.LoadUserPort;
 import popcong.app.domain.user.model.User;
@@ -14,9 +15,11 @@ public class GetMyProfileService implements GetMyProfileUseCase {
 
     private final LoadUserPort loadUserPort;
 
+
     @Override
-    public User getMyProfile(Long userId) {
-        return loadUserPort.loadUserById(userId)
-                .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+    public MyProfileResponseDto get(Long userId) {
+        User user = loadUserPort.loadUserById(userId)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.UNAUTHORIZED));
+        return MyProfileResponseDto.from(user); // 순수 매핑
     }
 }

--- a/src/main/java/popcong/app/application/user/service/GetMyProfileService.java
+++ b/src/main/java/popcong/app/application/user/service/GetMyProfileService.java
@@ -1,0 +1,22 @@
+package popcong.app.application.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import popcong.app.application.user.port.in.GetMyProfileUseCase;
+import popcong.app.application.user.port.out.LoadUserPort;
+import popcong.app.domain.user.model.User;
+import popcong.app.global.exception.custom.BusinessException;
+import popcong.app.global.exception.error.AuthErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class GetMyProfileService implements GetMyProfileUseCase {
+
+    private final LoadUserPort loadUserPort;
+
+    @Override
+    public User getMyProfile(Long userId) {
+        return loadUserPort.loadUserById(userId)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/popcong/app/application/user/service/UpdateMyProfileService.java
+++ b/src/main/java/popcong/app/application/user/service/UpdateMyProfileService.java
@@ -1,0 +1,21 @@
+package popcong.app.application.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import popcong.app.application.user.port.in.UpdateMyProfileUseCase;
+import popcong.app.application.user.port.out.UpdateUserPort;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateMyProfileService implements UpdateMyProfileUseCase {
+
+    private final UpdateUserPort updateUserPort;
+
+    /** name/introduction/profileImageUrl 각각 null 이면 “해당 항목은 변경 없음” 처리 */
+    @Override
+    @Transactional
+    public void update(Long userId, String name, String introduction, String profileImageUrl) {
+        updateUserPort.updateProfile(userId, name, introduction, profileImageUrl);
+    }
+}

--- a/src/main/java/popcong/app/global/exception/error/CommonErrorCode.java
+++ b/src/main/java/popcong/app/global/exception/error/CommonErrorCode.java
@@ -17,6 +17,8 @@ public enum CommonErrorCode implements ErrorCode {
     ENTITY_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "C4003", "Entity Not Found"),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED.value(), "C4004", "Invalid Http Method"),
     NO_REQUIRED_FILES(HttpStatus.BAD_REQUEST.value(), "C4005", "필수 제출 파일이 누락되었습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "CM404", "리소스를 찾을 수 없습니다."),
+
 
     // 5XX
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "C5001", "Internal Server Error");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,6 @@ spring:
     
 cloud:
   aws:
-    profile: dev
     region: us-east-2
     s3:
       bucket: popcongbucket


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#21 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요.

### 내 프로필 조회 기능
- UserController
   - GET /api/v1/user/mypage/me
   
- GetMyProfileService
   - GetMyProfileUseCase 구현체
   - User 도메인을 DTO(MyProfileResponse)로 변환
   
- UserPersistenceAdapter
   - UserJpaRepository 통해 DB 조회

### 내 프로필 편집 기능
- UserController
   - PATCH /api/v1/user/my/update-profile
   
- UpdateMyProfileService
   - S3 업로드 수행 후 UpdateUserPort로 위임

- UpdateUserAdapter
   - UserJpaRepository로 유저 조회

- UserJpaEntity -> 수정
  - 변경 책임을 가진 행위 메서드 제공

## 📸 Screenshot

### 내 프로필 조회 기능 성공
<img width="2048" height="1112" alt="image" src="https://github.com/user-attachments/assets/ee8513f8-8da3-4a15-b4b5-74200d0e8735" />

### 내 프로필 편집 기능 401 오류
<img width="2048" height="972" alt="image" src="https://github.com/user-attachments/assets/8a368646-8537-4ea8-bb75-5b2764f2cb0c" />

### 내 프로필 편집 기능 200
<img width="2048" height="1145" alt="image" src="https://github.com/user-attachments/assets/346e1e1a-59d5-449b-8e7b-c16ef3f79775" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.