### PR TITLE
[Feature #14] 인기 매물 리스트, 현 위치 팝업 정보 리스트 조회 API

### DIFF
--- a/src/main/java/popcong/app/adapter/in/user/HomeController.java
+++ b/src/main/java/popcong/app/adapter/in/user/HomeController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import popcong.app.application.space.dto.response.HomeSpaceListResponseDto;
+import popcong.app.application.space.port.in.SpaceQueryUseCase;
 import popcong.app.application.user.dto.response.HomeUserResponseDto;
 import popcong.app.application.user.port.in.GetHomeInfoUseCase;
 import popcong.app.domain.user.model.User;
@@ -22,6 +24,7 @@ import popcong.app.global.exception.error.AuthErrorCode;
 public class HomeController {
 
     private final GetHomeInfoUseCase getHomeInfoUseCase;
+    private final SpaceQueryUseCase spaceQueryUseCase;
 
     @GetMapping("/me")
     public ResponseDto<HomeUserResponseDto> getHomeInfo(
@@ -39,6 +42,30 @@ public class HomeController {
         return new ResponseDto<>(
                 HttpStatus.OK.value(),
                 "홈 정보 조회 성공",
+                result
+        );
+    }
+
+    // 홈 매물 정보 리스트
+    @GetMapping("/location")
+    public ResponseDto<HomeSpaceListResponseDto> getSpaceLocation(
+            @AuthenticationPrincipal User user,
+            @RequestParam(name = "latitude") Double latitude,
+            @RequestParam(name = "longitude") Double longitude
+    ) {
+        if (user == null) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        Long currentUserId = user.userId();
+
+        HomeSpaceListResponseDto result = spaceQueryUseCase.loadHomeSpaceList(
+                currentUserId, latitude, longitude
+        );
+
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
+                "지정 위치 기반 매물, 팝업 정보",
                 result
         );
     }

--- a/src/main/java/popcong/app/adapter/out/persistence/image/mapper/ImageMapper.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/image/mapper/ImageMapper.java
@@ -1,0 +1,20 @@
+package popcong.app.adapter.out.persistence.image.mapper;
+
+import org.springframework.stereotype.Component;
+import popcong.app.adapter.out.persistence.image.entity.ImageJpaEntity;
+import popcong.app.domain.image.model.Image;
+
+@Component
+public class ImageMapper {
+
+    public Image toDomain(ImageJpaEntity imageJpaEntity) {
+        return new Image(
+                imageJpaEntity.getImageId(),
+                imageJpaEntity.getImageUrl(),
+                imageJpaEntity.getSaveOrder(),
+                imageJpaEntity.getImageableId(),
+                imageJpaEntity.getImageableType(),
+                imageJpaEntity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/image/repository/ImageQueryAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/image/repository/ImageQueryAdapter.java
@@ -1,0 +1,29 @@
+package popcong.app.adapter.out.persistence.image.repository;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import popcong.app.adapter.out.persistence.image.mapper.ImageMapper;
+import popcong.app.application.image.port.out.ImageQueryPort;
+import popcong.app.domain.image.model.Image;
+import popcong.app.domain.image.model.ImageableType;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ImageQueryAdapter implements ImageQueryPort {
+
+    private final ImageJpaRepository imageJpaRepository;
+    private final ImageMapper imageMapper;
+
+    public List<Image> findSpaceImages(Long imageableId, ImageableType imageableType, int limit) {
+
+        return imageJpaRepository
+                .findByImageableIdAndImageableTypeOrderBySaveOrderAsc(imageableId, imageableType)
+                .stream()
+                .limit(limit)
+                .map(imageMapper::toDomain)
+                .toList();
+    }
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/space/entity/SpaceJpaEntity.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/entity/SpaceJpaEntity.java
@@ -82,6 +82,9 @@ public class SpaceJpaEntity {
     @Column(name = "longitude", nullable = false)
     private Double longitude;
 
+    @Column(name = "geoAdvantage", nullable = true, length = 30)
+    private String geoAdvantage;
+
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)

--- a/src/main/java/popcong/app/adapter/out/persistence/space/mapper/SpaceMapper.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/mapper/SpaceMapper.java
@@ -26,6 +26,7 @@ public class SpaceMapper {
                 entity.getLocation(),
                 entity.getLatitude(),
                 entity.getLongitude(),
+                entity.getGeoAdvantage(),
                 entity.getStatus(),
                 entity.getViews()
         );

--- a/src/main/java/popcong/app/adapter/out/persistence/space/repository/PopupQueryAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/repository/PopupQueryAdapter.java
@@ -1,0 +1,69 @@
+package popcong.app.adapter.out.persistence.space.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import popcong.app.adapter.out.persistence.space.entity.QPopupJpaEntity;
+import popcong.app.adapter.out.persistence.space.entity.QReservationJpaEntity;
+import popcong.app.adapter.out.persistence.space.entity.QSpaceJpaEntity;
+import popcong.app.application.space.dto.response.NearbyPopupInfoDto;
+import popcong.app.application.space.dto.response.NearbyPopupsDto;
+import popcong.app.application.space.port.out.PopupQueryPort;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class PopupQueryAdapter implements PopupQueryPort {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // 근처 팝업 불러오기
+    @Override
+    public NearbyPopupsDto findNearbyPopups(double latitude, double longitude, double radiusKm, int limit) {
+
+        QPopupJpaEntity popup = QPopupJpaEntity.popupJpaEntity;
+        QReservationJpaEntity reservation = QReservationJpaEntity.reservationJpaEntity;
+        QSpaceJpaEntity space = QSpaceJpaEntity.spaceJpaEntity;
+
+        // 바운더리 결정
+        double deltaLat = radiusKm / 111.0; // 위도 1도 ≈ 111km
+        double deltaLng = radiusKm / (111.0 * Math.cos(Math.toRadians(latitude + deltaLat)));
+
+        NumberTemplate<Double> distanceKm = com.querydsl.core.types.dsl.Expressions.numberTemplate(
+                Double.class,
+                "6371 * acos(least(greatest((cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({0})) * sin(radians({1}))), -1), 1))",
+                latitude,
+                space.latitude,
+                space.longitude,
+                longitude
+        );
+
+        List<NearbyPopupInfoDto> nearbyPopups = jpaQueryFactory
+                .select(Projections.constructor(
+                        NearbyPopupInfoDto.class,
+                        popup.popupId,
+                        popup.name,
+                        popup.address,
+                        popup.startDate,
+                        popup.endDate
+                ))
+                .from(popup)
+                .join(popup.reservation, reservation)
+                .join(reservation.space, space)
+                .where(
+                        space.latitude.between(latitude - deltaLat, latitude + deltaLat),
+                        space.longitude.between(longitude - deltaLng, longitude + deltaLng),
+                        distanceKm.loe(radiusKm)
+                )
+                .orderBy(distanceKm.asc(), popup.startDate.asc())
+                .limit(limit)
+                .fetch();
+
+        return new NearbyPopupsDto(nearbyPopups);
+    }
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/space/repository/SpaceQueryAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/repository/SpaceQueryAdapter.java
@@ -1,0 +1,32 @@
+package popcong.app.adapter.out.persistence.space.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import popcong.app.adapter.out.persistence.space.entity.QSpaceJpaEntity;
+import popcong.app.adapter.out.persistence.space.entity.SpaceJpaEntity;
+import popcong.app.adapter.out.persistence.space.mapper.SpaceMapper;
+import popcong.app.application.space.port.out.SpaceQueryPort;
+import popcong.app.domain.space.model.Space;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SpaceQueryAdapter implements SpaceQueryPort {
+
+    private final JPAQueryFactory queryFactory;
+    private final SpaceMapper spaceMapper;
+
+    public List<Space> findPopularSpaceTop20() {
+        QSpaceJpaEntity spaceEntity = QSpaceJpaEntity.spaceJpaEntity;
+
+        List<SpaceJpaEntity> entities = queryFactory
+                .selectFrom(spaceEntity)
+                .orderBy(spaceEntity.views.desc())
+                .limit(20)
+                .fetch();
+
+        return entities.stream().map(spaceMapper::toDomain).toList();
+    };
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/user/repository/WishlistJpaRepository.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/user/repository/WishlistJpaRepository.java
@@ -1,0 +1,14 @@
+package popcong.app.adapter.out.persistence.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import popcong.app.adapter.out.persistence.user.entity.WishlistJpaEntity;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface WishlistJpaRepository extends JpaRepository<WishlistJpaEntity, Long> {
+    boolean existsByUser_UserIdAndSpace_SpaceId(Long userId, Long spaceId);
+
+
+    List<WishlistJpaEntity> findByUser_UserIdAndSpace_SpaceIdIn(Long userId, Collection<Long> spaceIds);
+}

--- a/src/main/java/popcong/app/adapter/out/persistence/user/repository/WishlistQueryAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/user/repository/WishlistQueryAdapter.java
@@ -1,0 +1,35 @@
+package popcong.app.adapter.out.persistence.user.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import popcong.app.application.user.port.out.WishlistQueryPort;
+
+import java.util.Collection;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class WishlistQueryAdapter implements WishlistQueryPort {
+
+    private final WishlistJpaRepository wishlistJpaRepository;
+
+    @Override
+    public Set<Long> findWishedSpaceIds(Long userId, Collection<Long> spaceIds) {
+        if (userId == null || spaceIds == null || spaceIds.isEmpty()) {
+            return Set.of();
+        }
+
+        return wishlistJpaRepository
+                .findByUser_UserIdAndSpace_SpaceIdIn(userId, spaceIds).stream()
+                .map(w -> w.getSpace().getSpaceId())
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    @Override
+    public boolean existsByUserIdAndSpaceId(Long userId, Long spaceId) {
+        if (userId == null || spaceId == null) return false;
+        return wishlistJpaRepository.existsByUser_UserIdAndSpace_SpaceId(userId, spaceId);
+    }
+}

--- a/src/main/java/popcong/app/application/image/port/out/ImageQueryPort.java
+++ b/src/main/java/popcong/app/application/image/port/out/ImageQueryPort.java
@@ -1,0 +1,11 @@
+package popcong.app.application.image.port.out;
+
+import popcong.app.domain.image.model.Image;
+import popcong.app.domain.image.model.ImageableType;
+
+import java.util.List;
+
+public interface ImageQueryPort {
+
+    List<Image> findSpaceImages(Long spaceId, ImageableType imageableType, int limit);
+}

--- a/src/main/java/popcong/app/application/space/dto/response/HomeSpaceListResponseDto.java
+++ b/src/main/java/popcong/app/application/space/dto/response/HomeSpaceListResponseDto.java
@@ -1,0 +1,6 @@
+package popcong.app.application.space.dto.response;
+
+public record HomeSpaceListResponseDto(
+        PopularSpacesDto popularSpacesDto,
+        NearbyPopupsDto nearbyPopupsDto
+) {}

--- a/src/main/java/popcong/app/application/space/dto/response/NearbyPopupInfoDto.java
+++ b/src/main/java/popcong/app/application/space/dto/response/NearbyPopupInfoDto.java
@@ -1,0 +1,11 @@
+package popcong.app.application.space.dto.response;
+
+import java.time.LocalDateTime;
+
+public record NearbyPopupInfoDto(
+        Long popupId,
+        String name,
+        String address,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+) {}

--- a/src/main/java/popcong/app/application/space/dto/response/NearbyPopupsDto.java
+++ b/src/main/java/popcong/app/application/space/dto/response/NearbyPopupsDto.java
@@ -1,0 +1,7 @@
+package popcong.app.application.space.dto.response;
+
+import java.util.List;
+
+public record NearbyPopupsDto(
+        List<NearbyPopupInfoDto> nearbyPopups
+) {}

--- a/src/main/java/popcong/app/application/space/dto/response/PopularSpaceInfoDto.java
+++ b/src/main/java/popcong/app/application/space/dto/response/PopularSpaceInfoDto.java
@@ -1,0 +1,16 @@
+package popcong.app.application.space.dto.response;
+
+import java.util.List;
+
+public record PopularSpaceInfoDto(
+   Long spaceId,
+   String spaceName,
+   List<String> imageUrl,
+   String address,
+   Double rating,
+   Integer rentalFee,
+   Integer deposit,
+   String geoAdvantage,
+   Boolean isWished,
+   Long reviewCount
+) {}

--- a/src/main/java/popcong/app/application/space/dto/response/PopularSpacesDto.java
+++ b/src/main/java/popcong/app/application/space/dto/response/PopularSpacesDto.java
@@ -1,0 +1,7 @@
+package popcong.app.application.space.dto.response;
+
+import java.util.List;
+
+public record PopularSpacesDto(
+        List<PopularSpaceInfoDto> popularSpaces
+) {}

--- a/src/main/java/popcong/app/application/space/port/in/SpaceQueryUseCase.java
+++ b/src/main/java/popcong/app/application/space/port/in/SpaceQueryUseCase.java
@@ -1,0 +1,10 @@
+package popcong.app.application.space.port.in;
+
+import popcong.app.application.space.dto.response.HomeSpaceListResponseDto;
+import popcong.app.application.space.dto.response.PopularSpacesDto;
+
+public interface SpaceQueryUseCase {
+    PopularSpacesDto findPopularSpaceTop20(Long userId);
+
+    HomeSpaceListResponseDto loadHomeSpaceList(Long userId, double latitude, double longitude);
+}

--- a/src/main/java/popcong/app/application/space/port/out/PopupQueryPort.java
+++ b/src/main/java/popcong/app/application/space/port/out/PopupQueryPort.java
@@ -1,0 +1,7 @@
+package popcong.app.application.space.port.out;
+
+import popcong.app.application.space.dto.response.NearbyPopupsDto;
+
+public interface PopupQueryPort {
+    NearbyPopupsDto findNearbyPopups(double latitude, double longitude, double radiusKm, int limit);
+}

--- a/src/main/java/popcong/app/application/space/port/out/SpaceQueryPort.java
+++ b/src/main/java/popcong/app/application/space/port/out/SpaceQueryPort.java
@@ -1,0 +1,10 @@
+package popcong.app.application.space.port.out;
+
+import popcong.app.domain.space.model.Space;
+
+import java.util.List;
+
+public interface SpaceQueryPort {
+
+    List<Space> findPopularSpaceTop20();
+}

--- a/src/main/java/popcong/app/application/space/service/SpaceQueryService.java
+++ b/src/main/java/popcong/app/application/space/service/SpaceQueryService.java
@@ -1,0 +1,97 @@
+package popcong.app.application.space.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import popcong.app.application.image.port.out.ImageQueryPort;
+import popcong.app.application.space.dto.response.HomeSpaceListResponseDto;
+import popcong.app.application.space.dto.response.NearbyPopupsDto;
+import popcong.app.application.space.dto.response.PopularSpaceInfoDto;
+import popcong.app.application.space.dto.response.PopularSpacesDto;
+import popcong.app.application.space.port.in.SpaceQueryUseCase;
+import popcong.app.application.space.port.out.PopupQueryPort;
+import popcong.app.application.space.port.out.ReviewCountQueryPort;
+import popcong.app.application.space.port.out.SpaceQueryPort;
+import popcong.app.application.user.port.out.WishlistQueryPort;
+import popcong.app.domain.image.model.Image;
+import popcong.app.domain.image.model.ImageableType;
+import popcong.app.domain.space.model.Space;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class SpaceQueryService implements SpaceQueryUseCase {
+
+    private final SpaceQueryPort spaceQueryPort;
+    private final ImageQueryPort imageQueryPort;
+    private final WishlistQueryPort wishlistQueryPort;
+    private final ReviewCountQueryPort reviewCountQueryPort;
+    private final PopupQueryPort popupQueryPort;
+
+    // 홈 매물 조회 부분 비지니스 로직
+    @Override
+    public HomeSpaceListResponseDto loadHomeSpaceList(Long userId, double latitude, double longitude) {
+        PopularSpacesDto popularSpaces = findPopularSpaceTop20(userId);
+        NearbyPopupsDto nearbyPopupsDto = popupQueryPort.findNearbyPopups(latitude, longitude, 20.0, 20);
+
+        return new HomeSpaceListResponseDto(popularSpaces, nearbyPopupsDto);
+    }
+
+    // 인기 매물 20개 추출 - 조회수 기반
+    @Override
+    public PopularSpacesDto findPopularSpaceTop20(Long userId) {
+
+        // 인기 매물 20개 데이터 반환
+        List<Space> spaces = spaceQueryPort.findPopularSpaceTop20();
+
+        // 빈 리스트 반환 (데이터 없는 경우)
+        if (spaces.isEmpty()) {
+            return new PopularSpacesDto(List.of());
+        }
+
+        // spaceId, isWished 조회
+        List<Long> spaceIds = spaces.stream().map(Space::spaceId).toList();
+        Set<Long> wishIds = (userId == null) ? Set.of() : wishlistQueryPort.findWishedSpaceIds(userId, spaceIds);
+        Map<Long, Long> reviewCounts = reviewCountQueryPort.countBySpaceIds(spaceIds);
+
+        // 이미지 Dto 매핑
+        List<PopularSpaceInfoDto> popularSpaceInfoDtos = spaces.stream()
+                .map(space -> {
+                    List<String> imageUrls = imageQueryPort
+                            .findSpaceImages(space.spaceId(), ImageableType.SPACE, 5)
+                            .stream()
+                            .map(Image::imageUrl)
+                            .toList();
+
+                    boolean isWished = wishIds.contains(space.spaceId());
+                    Long reviewCount = reviewCounts.getOrDefault(space.spaceId(), 0L);
+
+                    return findPopularSpaceInfo(space, imageUrls, isWished, reviewCount);
+                })
+                .toList();
+
+        return new  PopularSpacesDto(popularSpaceInfoDtos);
+    }
+
+
+
+
+
+
+    private PopularSpaceInfoDto findPopularSpaceInfo(Space space, List<String> imageUrls, boolean isWished,  Long reviewCount) {
+        return new PopularSpaceInfoDto(
+                space.spaceId(),
+                space.spaceName(),
+                imageUrls,
+                space.address(),
+                space.rating(),
+                space.rentalFee(),
+                space.deposit(),
+                space.geoAdvantage(),
+                isWished,
+                reviewCount
+        );
+    }
+}

--- a/src/main/java/popcong/app/application/user/port/out/WishlistQueryPort.java
+++ b/src/main/java/popcong/app/application/user/port/out/WishlistQueryPort.java
@@ -1,0 +1,10 @@
+package popcong.app.application.user.port.out;
+
+import java.util.Collection;
+import java.util.Set;
+
+public interface WishlistQueryPort {
+    Set<Long> findWishedSpaceIds(Long userId, Collection<Long> spaceIds);
+
+    boolean existsByUserIdAndSpaceId(Long userId, Long spaceId);
+}

--- a/src/main/java/popcong/app/domain/space/model/Space.java
+++ b/src/main/java/popcong/app/domain/space/model/Space.java
@@ -18,6 +18,7 @@ public record Space(
         String location,
         Double latitude,
         Double longitude,
+        String geoAdvantage,
         Status status,
         Integer views
 ) {


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#14 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요.

- 조회수를 기준으로 인기 매물 20개 조회
- 각 매물 이미지 리스트 조회
- 위시리스트 추가 여부 조회
- 현 위치(latitude, longitude) 기반 20km 반경 팝업 정보 리스트 반환

- 일반 테스트
<img width="1470" height="1456" alt="image" src="https://github.com/user-attachments/assets/f39e8146-39f3-4b0f-b5c9-fa5a63c88aba" />

- 근처에 팝업이 없는 경우
<img width="1474" height="1388" alt="image" src="https://github.com/user-attachments/assets/45219777-002e-4308-8c36-ea6cbfdab23d" />

- 조회수 수정 후 테스트
<img width="1476" height="1364" alt="image" src="https://github.com/user-attachments/assets/bdea4303-bc8d-440d-9923-32d543792340" />
<img width="596" height="274" alt="image" src="https://github.com/user-attachments/assets/ef1caff0-dfb8-4f94-ad8d-751acfbe90e1" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.