### PR TITLE
[ Refactor ] 홈 화면 사용자 고유정보 수정

### DIFF
--- a/src/main/java/popcong/app/adapter/out/persistence/space/repository/ReservationQueryAdapter.java
+++ b/src/main/java/popcong/app/adapter/out/persistence/space/repository/ReservationQueryAdapter.java
@@ -1,0 +1,44 @@
+package popcong.app.adapter.out.persistence.space.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import popcong.app.adapter.out.persistence.space.entity.QPopupJpaEntity;
+import popcong.app.adapter.out.persistence.space.entity.QReservationJpaEntity;
+import popcong.app.adapter.out.persistence.space.entity.QSpaceJpaEntity;
+import popcong.app.application.user.dto.response.MyReservationItemDto;
+import popcong.app.application.user.port.out.ReservationQueryPort;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReservationQueryAdapter implements ReservationQueryPort {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MyReservationItemDto> findMyReservations(Long userId) {
+        QReservationJpaEntity r = QReservationJpaEntity.reservationJpaEntity;
+        QPopupJpaEntity p = QPopupJpaEntity.popupJpaEntity;
+        QSpaceJpaEntity s = QSpaceJpaEntity.spaceJpaEntity;
+
+        return queryFactory
+                .select(Projections.constructor(MyReservationItemDto.class,
+                        p.popupStatus,
+                        p.name,
+                        s.address,
+                        p.startDate,
+                        p.endDate
+                ))
+                .from(p)
+                .join(p.reservation, r)
+                .join(r.space, s)
+                .where(r.user.userId.eq(userId))
+                .orderBy(p.startDate.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/popcong/app/application/user/dto/response/HomeUserResponseDto.java
+++ b/src/main/java/popcong/app/application/user/dto/response/HomeUserResponseDto.java
@@ -1,16 +1,15 @@
 package popcong.app.application.user.dto.response;
 
-import popcong.app.application.space.dto.response.MyPopupItemResponseDto;
 import java.util.List;
 
 public record HomeUserResponseDto(
         UserInfoResponseDto userInfo,
-        List<MyPopupItemResponseDto> myPopups
+        List<MyReservationItemDto> myReservations
 ) {
-    public static HomeUserResponseDto from(UserResponseDto user, List<MyPopupItemResponseDto> popups) {
+    public static HomeUserResponseDto from(UserResponseDto user, List<MyReservationItemDto> reservations) {
         return new HomeUserResponseDto(
                 UserInfoResponseDto.from(user),
-                popups
+                reservations
         );
     }
 }

--- a/src/main/java/popcong/app/application/user/dto/response/MyReservationItemDto.java
+++ b/src/main/java/popcong/app/application/user/dto/response/MyReservationItemDto.java
@@ -1,0 +1,13 @@
+package popcong.app.application.user.dto.response;
+
+import popcong.app.domain.space.model.PopupStatus;
+
+import java.time.LocalDateTime;
+
+public record MyReservationItemDto(
+        PopupStatus status,
+        String popupName,
+        String address,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+) {}

--- a/src/main/java/popcong/app/application/user/port/out/ReservationQueryPort.java
+++ b/src/main/java/popcong/app/application/user/port/out/ReservationQueryPort.java
@@ -1,0 +1,9 @@
+package popcong.app.application.user.port.out;
+
+import popcong.app.application.user.dto.response.MyReservationItemDto;
+
+import java.util.List;
+
+public interface ReservationQueryPort {
+    List<MyReservationItemDto> findMyReservations(Long userId);
+}

--- a/src/main/java/popcong/app/application/user/port/out/WishListQueryPort.java
+++ b/src/main/java/popcong/app/application/user/port/out/WishListQueryPort.java
@@ -1,6 +1,9 @@
 package popcong.app.application.user.port.out;
 
+import popcong.app.application.user.dto.response.MyWishItemDto;
+
 import java.util.Collection;
+
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/popcong/app/application/user/service/HomeInfoService.java
+++ b/src/main/java/popcong/app/application/user/service/HomeInfoService.java
@@ -5,11 +5,12 @@ import org.springframework.stereotype.Service;
 
 import org.springframework.transaction.annotation.Transactional;
 import popcong.app.application.user.dto.response.HomeUserResponseDto;
+import popcong.app.application.user.dto.response.MyReservationItemDto;
 import popcong.app.application.user.dto.response.UserResponseDto;
 import popcong.app.application.user.port.in.GetHomeInfoUseCase;
-import popcong.app.application.user.port.out.LoadMyPopupsPort;
 import popcong.app.application.user.port.out.LoadUserPort;
-import popcong.app.application.space.dto.response.MyPopupItemResponseDto;
+
+import popcong.app.application.user.port.out.ReservationQueryPort;
 import popcong.app.domain.user.model.User;
 import popcong.app.global.exception.custom.BusinessException;
 import popcong.app.global.exception.error.AuthErrorCode;
@@ -18,24 +19,24 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class HomeInfoService implements GetHomeInfoUseCase {
 
     private final LoadUserPort loadUserPort;
-    private final LoadMyPopupsPort loadMyPopupsPort;
+    private final ReservationQueryPort reservationQueryPort;
 
     @Override
-    @Transactional(readOnly = true)
     public HomeUserResponseDto getMyHomeInfo(Long userId) {
         // 사용자 조회 (없으면 예외)
         User user = loadUserPort.loadUserById(userId)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.UNAUTHORIZED));
 
         // 내 팝업 조회
-        List<MyPopupItemResponseDto> myPopups =
-                loadMyPopupsPort.findMyPopups(userId);
+        List<MyReservationItemDto> myReservations =
+                reservationQueryPort.findMyReservations(userId);
 
         // 응답 DTO 조합
-        return HomeUserResponseDto.from(UserResponseDto.from(user), myPopups);
+        return HomeUserResponseDto.from(UserResponseDto.from(user), myReservations);
     }
 
 }


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#45

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요.

### DTO
- Before: HomeUserResponseDto 안에 myPopups (→ MyPopupItemResponseDto)
- After: HomeUserResponseDto 안에 myReservations (→ MyReservationItemDto)
→ 이제 API 응답에 status, popupName, address, startDate, endDate만 담김.

### Service
- Before: HomeInfoService가 LoadMyPopupsPort를 사용해서 myPopups 조회
- After: HomeInfoService가 ReservationQueryPort를 사용해서 myReservations 조회
→ 사용자 ID로 예약 내역을 가져오고 DTO로 변환.

### Port
- Before: LoadMyPopupsPort (popup 중심 조회)
- After: ReservationQueryPort (reservation 중심 조회)
→ 포트 역할이 “예약” 중심으로 변경.

### Adapter
- Before: LoadMyPopupsPersistenceAdapter + PopupEntityMapper → 팝업 + 공간 정보 매핑
- After: ReservationQueryAdapter (QueryDSL) → Reservation + Popup + Space를 한 번에 조인해서 MyReservationItemDto.


### Controller
- /api/v1/popup/home/me 그대로 유지
- 응답 구조: userInfo + myReservations[]


## 📸 Screenshot
<img width="2048" height="1321" alt="image" src="https://github.com/user-attachments/assets/41f18c36-58ec-4711-b18a-181fee25cf18" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.